### PR TITLE
Add Spanish layout and F-key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ Supports Flatpak's RemoteDesktop portal (for Wayland), Windows and X11.
     go install github.com/unrud/remote-touchpad@latest
     ```
 
+### Debian XFCE (Spanish keyboard)
+
+Para usar Remote Touchpad en Debian con XFCE y teclado español ejecuta:
+
+```sh
+REMOTE_TOUCHPAD_UINPUT_KEYMAP=es ./remote-touchpad
+```
+
+Esto habilita todas las teclas, incluidas F1–F12, usando la disposición española.
+
 ## Screenshots
 
 ![screenshot 1](https://raw.githubusercontent.com/Unrud/remote-touchpad/master/screenshots/1.png)

--- a/inputcontrol/controller.go
+++ b/inputcontrol/controller.go
@@ -50,6 +50,18 @@ const (
 	KeyBackSpace
 	KeyDelete
 	KeyReturn
+	KeyF1
+	KeyF2
+	KeyF3
+	KeyF4
+	KeyF5
+	KeyF6
+	KeyF7
+	KeyF8
+	KeyF9
+	KeyF10
+	KeyF11
+	KeyF12
 	KeyLimit
 )
 

--- a/inputcontrol/controller_uinput.go
+++ b/inputcontrol/controller_uinput.go
@@ -133,6 +133,30 @@ func (p *uinputController) KeyboardKey(key Key) error {
 		uinputKey = uinput.KeyBackspace
 	case KeyReturn:
 		uinputKey = uinput.KeyEnter
+	case KeyF1:
+		uinputKey = uinput.KeyF1
+	case KeyF2:
+		uinputKey = uinput.KeyF2
+	case KeyF3:
+		uinputKey = uinput.KeyF3
+	case KeyF4:
+		uinputKey = uinput.KeyF4
+	case KeyF5:
+		uinputKey = uinput.KeyF5
+	case KeyF6:
+		uinputKey = uinput.KeyF6
+	case KeyF7:
+		uinputKey = uinput.KeyF7
+	case KeyF8:
+		uinputKey = uinput.KeyF8
+	case KeyF9:
+		uinputKey = uinput.KeyF9
+	case KeyF10:
+		uinputKey = uinput.KeyF10
+	case KeyF11:
+		uinputKey = uinput.KeyF11
+	case KeyF12:
+		uinputKey = uinput.KeyF12
 	case KeyDelete:
 		uinputKey = uinput.KeyDelete
 	case KeyHome:

--- a/inputcontrol/controller_windows.go
+++ b/inputcontrol/controller_windows.go
@@ -43,6 +43,18 @@ const (
 	vkRight          uint16 = 0x27
 	vkDown           uint16 = 0x28
 	vkDelete         uint16 = 0x2E
+	vkF1             uint16 = 0x70
+	vkF2             uint16 = 0x71
+	vkF3             uint16 = 0x72
+	vkF4             uint16 = 0x73
+	vkF5             uint16 = 0x74
+	vkF6             uint16 = 0x75
+	vkF7             uint16 = 0x76
+	vkF8             uint16 = 0x77
+	vkF9             uint16 = 0x78
+	vkF10            uint16 = 0x79
+	vkF11            uint16 = 0x7A
+	vkF12            uint16 = 0x7B
 	vkLwin           uint16 = 0x5B
 	vkBrowserBack    uint16 = 0xA6
 	vkBrowserForward uint16 = 0xA7
@@ -139,6 +151,30 @@ func (p *windowsController) KeyboardKey(key Key) error {
 		input.wVk = vkBack
 	case KeyReturn:
 		input.wVk = vkReturn
+	case KeyF1:
+		input.wVk = vkF1
+	case KeyF2:
+		input.wVk = vkF2
+	case KeyF3:
+		input.wVk = vkF3
+	case KeyF4:
+		input.wVk = vkF4
+	case KeyF5:
+		input.wVk = vkF5
+	case KeyF6:
+		input.wVk = vkF6
+	case KeyF7:
+		input.wVk = vkF7
+	case KeyF8:
+		input.wVk = vkF8
+	case KeyF9:
+		input.wVk = vkF9
+	case KeyF10:
+		input.wVk = vkF10
+	case KeyF11:
+		input.wVk = vkF11
+	case KeyF12:
+		input.wVk = vkF12
 	case KeyEnd:
 		input.wVk = vkEnd
 	case KeyHome:

--- a/inputcontrol/keysyms.go
+++ b/inputcontrol/keysyms.go
@@ -38,6 +38,18 @@ const (
 	xkRight     Keysym = 0xff53
 	xkDown      Keysym = 0xff54
 	xkEnd       Keysym = 0xff57
+	xkF1        Keysym = 0xffbe
+	xkF2        Keysym = 0xffbf
+	xkF3        Keysym = 0xffc0
+	xkF4        Keysym = 0xffc1
+	xkF5        Keysym = 0xffc2
+	xkF6        Keysym = 0xffc3
+	xkF7        Keysym = 0xffc4
+	xkF8        Keysym = 0xffc5
+	xkF9        Keysym = 0xffc6
+	xkF10       Keysym = 0xffc7
+	xkF11       Keysym = 0xffc8
+	xkF12       Keysym = 0xffc9
 	xkSuperL    Keysym = 0xffeb
 	// X11/XF86keysym.h
 	xf86xkAudioLowerVolume Keysym = 0x1008ff11
@@ -71,6 +83,30 @@ func KeyToKeysym(key Key) (Keysym, error) {
 		return xkBackSpace, nil
 	case KeyReturn:
 		return xkReturn, nil
+	case KeyF1:
+		return xkF1, nil
+	case KeyF2:
+		return xkF2, nil
+	case KeyF3:
+		return xkF3, nil
+	case KeyF4:
+		return xkF4, nil
+	case KeyF5:
+		return xkF5, nil
+	case KeyF6:
+		return xkF6, nil
+	case KeyF7:
+		return xkF7, nil
+	case KeyF8:
+		return xkF8, nil
+	case KeyF9:
+		return xkF9, nil
+	case KeyF10:
+		return xkF10, nil
+	case KeyF11:
+		return xkF11, nil
+	case KeyF12:
+		return xkF12, nil
 	case KeyDelete:
 		return xkDelete, nil
 	case KeyHome:

--- a/webdata/app/inputcontroller.mjs
+++ b/webdata/app/inputcontroller.mjs
@@ -39,6 +39,18 @@ export const KEY_END = 14;
 export const KEY_BACK_SPACE = 15;
 export const KEY_DELETE = 16;
 export const KEY_RETURN = 17;
+export const KEY_F1 = 18;
+export const KEY_F2 = 19;
+export const KEY_F3 = 20;
+export const KEY_F4 = 21;
+export const KEY_F5 = 22;
+export const KEY_F6 = 23;
+export const KEY_F7 = 24;
+export const KEY_F8 = 25;
+export const KEY_F9 = 26;
+export const KEY_F10 = 27;
+export const KEY_F11 = 28;
+export const KEY_F12 = 29;
 
 export default class InputController {
     #updateRate = 0;

--- a/webdata/app/keyboard.mjs
+++ b/webdata/app/keyboard.mjs
@@ -20,6 +20,8 @@
 import {
     KEY_SUPER, KEY_BACK_SPACE, KEY_RETURN, KEY_DELETE, KEY_HOME, KEY_END,
     KEY_LEFT, KEY_RIGHT, KEY_UP, KEY_DOWN,
+    KEY_F1, KEY_F2, KEY_F3, KEY_F4, KEY_F5, KEY_F6,
+    KEY_F7, KEY_F8, KEY_F9, KEY_F10, KEY_F11, KEY_F12,
 } from "./inputcontroller.mjs";
 
 export default class Keyboard {
@@ -60,6 +62,11 @@ export default class Keyboard {
             key = KEY_UP;
         } else if (event.key == "Down" || event.key == "ArrowDown") {
             key = KEY_DOWN;
+        } else if (event.key.startsWith("F")) {
+            const n = parseInt(event.key.substring(1));
+            if (n >= 1 && n <= 12) {
+                key = KEY_F1 + (n - 1);
+            }
         }
         if (key != null) {
             if (!event.shiftKey) {

--- a/webdata/index.html
+++ b/webdata/index.html
@@ -91,6 +91,22 @@
         <button style="grid-row: 5; grid-column: 1 / 3" onclick="app.text(this.textContent)">0</button>
         <button onclick="app.text(this.textContent)"><script>document.write(Intl.NumberFormat().formatToParts(1.1).find(x => x.type === "decimal").value)</script></button>
     </div>
+    <div class="page">
+        <button onclick="app.key(app.KEY_F1)">F1</button>
+        <button onclick="app.key(app.KEY_F2)">F2</button>
+        <button onclick="app.key(app.KEY_F3)">F3</button>
+        <button onclick="app.key(app.KEY_F4)">F4</button>
+
+        <button onclick="app.key(app.KEY_F5)">F5</button>
+        <button onclick="app.key(app.KEY_F6)">F6</button>
+        <button onclick="app.key(app.KEY_F7)">F7</button>
+        <button onclick="app.key(app.KEY_F8)">F8</button>
+
+        <button onclick="app.key(app.KEY_F9)">F9</button>
+        <button onclick="app.key(app.KEY_F10)">F10</button>
+        <button onclick="app.key(app.KEY_F11)">F11</button>
+        <button onclick="app.key(app.KEY_F12)">F12</button>
+    </div>
     <button class="top right" onclick="app.setKeysPage(1, true)">⮂</button>
     <button class="top left" onclick="history.back()">⯇</button>
 </div>


### PR DESCRIPTION
## Summary
- add function key constants and mappings
- export F1..F12 through the web UI
- add Spanish XFCE instructions

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68475f3ab8b88327ae43c677d0b5bb16